### PR TITLE
fix player.rb attributes bug

### DIFF
--- a/lib/elo_rating/match.rb
+++ b/lib/elo_rating/match.rb
@@ -19,8 +19,8 @@ class EloRating::Match
   #
   # Raises an +ArgumentError+ if the rating or place is not numeric, or if
   # both winner and place is specified.
-  def add_player(player_attributes)
-    players << Player.new(player_attributes.merge(match: self))
+  def add_player(**player_attributes)
+    players << Player.new(**(player_attributes.merge(match: self)))
     self
   end
 


### PR DESCRIPTION
Fix bug, 
when you try to `match.add_player(rating: 1500, place: 1)`:
`wrong number of arguments (given 1, expected 0; required keywords: match, rating) (ArgumentError)`